### PR TITLE
feat: 增加对多种搜索提供方的支持，包括Bing和Google CSE，并添加相关配置选项

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,18 +1,22 @@
 # app.py
 import webbrowser
+import logging
 
 # 导入UI创建函数
 from ui import create_ui
 # 导入逻辑层和工具函数
 import logic
 from utils import helpers
-from config import APP_PORT_START, APP_PORT_END, APP_HOST
+from config import APP_PORT_START, APP_PORT_END, APP_HOST, LOGGING_LEVEL, LOGGING_FORMAT
 
 
 def main():
     """
     主程序入口。
     """
+    # 初始化日志（确保 web_search 等模块的调试信息可见）
+    logging.basicConfig(level=getattr(logging, LOGGING_LEVEL, logging.INFO), format=LOGGING_FORMAT)
+
     # 1. 检查环境依赖
     print("🚀 正在启动智能文档问答系统...")
     print("Step 1/4: 检查系统环境...")

--- a/config.py
+++ b/config.py
@@ -47,6 +47,10 @@ os.environ['HF_ENDPOINT'] = _config["system"]["hf_endpoint"]
 
 # --- Search Engine ---
 SEARCH_ENGINE = _config["search"]["engine"]
+# 新增：搜索提供方（auto/serpapi/bing/google_cse/duckduckgo）
+SEARCH_PROVIDER = _config["search"].get("provider", "auto")
+# 新增：单次搜索的整体超时（秒），用于快速失败
+SEARCH_OVERALL_TIMEOUT = _config["search"].get("overall_timeout", 8)
 
 # --- Rerank Method ---
 RERANK_METHOD = os.getenv("RERANK_METHOD", _config["rerank_method"])
@@ -65,6 +69,15 @@ DEEPSEEK_API_URL = os.getenv("DEEPSEEK_API_URL", _config["endpoints"].get("deeps
 # 阿里云 DashScope 兼容
 DASHSCOPE_API_KEY = os.getenv("DASHSCOPE_API_KEY")
 ALIYUN_API_URL = os.getenv("ALIYUN_API_URL", _config["endpoints"].get("aliyun", "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"))
+
+# 新增：Bing Web Search（Azure Cognitive Services）
+BING_SEARCH_API_KEY = os.getenv("BING_SEARCH_API_KEY")
+BING_SEARCH_API_URL = os.getenv("BING_SEARCH_API_URL", _config["endpoints"].get("bing", "https://api.bing.microsoft.com/v7.0/search"))
+
+# 新增：Google Custom Search (CSE)
+GOOGLE_CSE_API_KEY = os.getenv("GOOGLE_CSE_API_KEY")
+GOOGLE_CSE_CX = os.getenv("GOOGLE_CSE_CX")
+GOOGLE_CSE_API_URL = os.getenv("GOOGLE_CSE_API_URL", _config["endpoints"].get("google_cse", "https://www.googleapis.com/customsearch/v1"))
 
 # 本地 Ollama
 OLLAMA_API_URL = _config["endpoints"]["ollama_generate"]

--- a/config_models.yaml
+++ b/config_models.yaml
@@ -34,6 +34,9 @@ endpoints:
   # 新增：DeepSeek 与 阿里云 OpenAI 兼容端点
   deepseek: "https://api.deepseek.com/v1/chat/completions"
   aliyun: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+  # 新增：Bing 与 Google CSE 端点（可选覆盖）
+  bing: "https://api.bing.microsoft.com/v7.0/search"
+  google_cse: "https://www.googleapis.com/customsearch/v1"
 
 # 搜索配置
 search:
@@ -41,6 +44,8 @@ search:
   num_results: 5
   language: "zh-CN"
   country: "cn"
+  # 新增：搜索提供方选择。可选：auto | serpapi | bing | google_cse | duckduckgo
+  provider: "duckduckgo"
 
 # 重排序方法
 rerank_method: "cross_encoder"

--- a/core/web_search.py
+++ b/core/web_search.py
@@ -1,25 +1,150 @@
 # core/web_search.py
-import requests
 import logging
+import requests
+from requests.adapters import HTTPAdapter
+import importlib
 from config import (
     SERPAPI_KEY, SEARCH_ENGINE, SERPAPI_URL, SEARCH_NUM_RESULTS,
-    SEARCH_LANGUAGE, SEARCH_COUNTRY, SERPAPI_TIMEOUT
+    SEARCH_LANGUAGE, SEARCH_COUNTRY, SERPAPI_TIMEOUT,
+    # 提供方与多引擎支持
+    SEARCH_PROVIDER, BING_SEARCH_API_KEY, BING_SEARCH_API_URL,
+    HTTP_RETRIES,
+    # Google CSE
+    GOOGLE_CSE_API_KEY, GOOGLE_CSE_CX, GOOGLE_CSE_API_URL,
 )
 
+# 复用会话以提升网络可靠性
+session = requests.Session()
+session.mount('http://', HTTPAdapter(max_retries=HTTP_RETRIES))
+session.mount('https://', HTTPAdapter(max_retries=HTTP_RETRIES))
 
-def check_serpapi_key():
-    return SERPAPI_KEY and SERPAPI_KEY.strip() != ""
+
+def check_serpapi_key() -> bool:
+    return bool(SERPAPI_KEY and SERPAPI_KEY.strip())
 
 
-def serpapi_search(query: str, num_results: int = None) -> list:
-    """执行SerpAPI搜索并返回结构化结果。"""
-    # TODO: (改进方向) 多元数据源接入
-    # 思路: 这里可以很容易地替换为其他搜索引擎API，如 Tavily, SearxNG, Google Custom Search API等。
-    # 只需修改这里的API调用逻辑，并保持返回格式一致即可。
+def check_bing_key() -> bool:
+    return bool(BING_SEARCH_API_KEY and BING_SEARCH_API_KEY.strip())
+
+
+def get_last_search_count() -> int | None:
+    """返回最近一次 web_search 返回的结果数。"""
+    return LAST_SEARCH_COUNT
+
+
+def get_last_search_provider() -> str | None:
+    """返回最近一次 web_search 实际使用的搜索提供方。"""
+    return LAST_SEARCH_PROVIDER
+
+
+def check_google_cse() -> bool:
+    return bool(GOOGLE_CSE_API_KEY and GOOGLE_CSE_CX)
+
+
+def _parse_serpapi_results(payload: dict) -> list:
+    results = []
+    try:
+        for item in payload.get("organic_results", []) or []:
+            results.append({
+                "title": item.get("title"),
+                "url": item.get("link"),
+                "snippet": item.get("snippet"),
+            })
+    except Exception as e:
+        logging.error(f"解析 SerpAPI 结果失败: {e}")
+    return results
+
+
+def _parse_bing_results(payload: dict) -> list:
+    results = []
+    try:
+        for item in (payload.get("webPages", {}) or {}).get("value", []) or []:
+            results.append({
+                "title": item.get("name"),
+                "url": item.get("url"),
+                "snippet": item.get("snippet"),
+            })
+    except Exception as e:
+        logging.error(f"解析 Bing 结果失败: {e}")
+    return results
+
+
+def _parse_google_cse_results(payload: dict) -> list:
+    results = []
+    try:
+        for item in payload.get("items", []) or []:
+            results.append({
+                "title": item.get("title"),
+                "url": item.get("link"),
+                "snippet": item.get("snippet"),
+            })
+    except Exception as e:
+        logging.error(f"解析 Google CSE 结果失败: {e}")
+    return results
+
+
+def _map_ddg_region(lang: str) -> str:
+    mapping = {
+        "zh-CN": "cn-zh",
+        "zh-TW": "tw-zh",
+        "zh-HK": "hk-zh",
+        "en-US": "us-en",
+        "en-GB": "uk-en",
+        "ja-JP": "jp-ja",
+    }
+    return mapping.get((lang or "").strip(), "wt-wt")
+
+
+def _load_ddgs():
+    """动态加载 DDG 客户端，优先 ddgs，回退 duckduckgo_search。"""
+    try:
+        mod = importlib.import_module("ddgs")
+        cls = getattr(mod, "DDGS", None)
+        if cls is not None:
+            return cls, "ddgs"
+    except Exception:
+        pass
+    try:
+        mod = importlib.import_module("duckduckgo_search")
+        cls = getattr(mod, "DDGS", None)
+        if cls is not None:
+            return cls, "duckduckgo_search"
+    except Exception:
+        pass
+    return None, None
+
+
+def _ddg_search(query: str, num_results: int | None = None) -> list:
+    if num_results is None:
+        num_results = SEARCH_NUM_RESULTS
+
+    DDGS, using_pkg = _load_ddgs()
+    if DDGS is None:
+        logging.warning("未安装 ddgs/duckduckgo-search，无法使用 DuckDuckGo 搜索。")
+        return []
+
+    region = _map_ddg_region(SEARCH_LANGUAGE)
+    results = []
+    try:
+        with DDGS(timeout=SERPAPI_TIMEOUT) as ddgs:
+            for item in ddgs.text(query, region=region, safesearch="moderate", timelimit=None, max_results=num_results):
+                results.append({
+                    "title": item.get("title"),
+                    "url": item.get("href"),
+                    "snippet": item.get("body"),
+                })
+        if using_pkg == "duckduckgo_search":
+            logging.debug("提示：建议将依赖从 'duckduckgo-search' 迁移到 'ddgs' 以消除弃用告警。")
+        return results
+    except Exception as e:
+        logging.error(f"DuckDuckGo 搜索失败: {e}")
+        return []
+
+
+def _serpapi_search(query: str, num_results: int | None = None) -> list:
     if not check_serpapi_key():
         raise ValueError("未设置 SERPAPI_KEY。")
 
-    # 使用配置中的默认值，除非明确指定
     if num_results is None:
         num_results = SEARCH_NUM_RESULTS
 
@@ -29,23 +154,148 @@ def serpapi_search(query: str, num_results: int = None) -> list:
         "api_key": SERPAPI_KEY,
         "num": num_results,
         "hl": SEARCH_LANGUAGE,
-        "gl": SEARCH_COUNTRY
+        "gl": SEARCH_COUNTRY,
     }
     try:
-        response = requests.get(SERPAPI_URL, params=params, timeout=SERPAPI_TIMEOUT)
-        response.raise_for_status()
-        search_data = response.json()
-
-        # 解析结果
-        results = []
-        if "organic_results" in search_data:
-            for item in search_data["organic_results"]:
-                results.append({
-                    "title": item.get("title"),
-                    "url": item.get("link"),
-                    "snippet": item.get("snippet"),
-                })
-        return results
+        resp = session.get(SERPAPI_URL, params=params, timeout=SERPAPI_TIMEOUT)
+        resp.raise_for_status()
+        return _parse_serpapi_results(resp.json())
     except Exception as e:
-        logging.error(f"网络搜索失败: {e}")
+        logging.error(f"SerpAPI 搜索失败: {e}")
         return []
+
+
+def _bing_search(query: str, num_results: int | None = None) -> list:
+    if not check_bing_key():
+        raise ValueError("未设置 BING_SEARCH_API_KEY。")
+
+    if num_results is None:
+        num_results = SEARCH_NUM_RESULTS
+
+    mkt = (SEARCH_LANGUAGE or "zh-CN").strip()
+    headers = {"Ocp-Apim-Subscription-Key": BING_SEARCH_API_KEY}
+    params = {"q": query, "count": num_results, "mkt": mkt}
+    try:
+        resp = session.get(BING_SEARCH_API_URL, headers=headers, params=params, timeout=SERPAPI_TIMEOUT)
+        resp.raise_for_status()
+        return _parse_bing_results(resp.json())
+    except Exception as e:
+        logging.error(f"Bing 搜索失败: {e}")
+        return []
+
+
+def _google_cse_search(query: str, num_results: int | None = None) -> list:
+    if not check_google_cse():
+        raise ValueError("未配置 GOOGLE_CSE_API_KEY 或 GOOGLE_CSE_CX。")
+
+    if num_results is None:
+        num_results = SEARCH_NUM_RESULTS
+
+    params = {
+        "q": query,
+        "key": GOOGLE_CSE_API_KEY,
+        "cx": GOOGLE_CSE_CX,
+        "num": max(1, min(10, num_results)),  # CSE 单次最多10条
+        "safe": "off",
+        "hl": (SEARCH_LANGUAGE or "zh-CN"),
+    }
+    try:
+        resp = session.get(GOOGLE_CSE_API_URL, params=params, timeout=SERPAPI_TIMEOUT)
+        resp.raise_for_status()
+        return _parse_google_cse_results(resp.json())
+    except Exception as e:
+        logging.error(f"Google CSE 搜索失败: {e}")
+        return []
+
+
+# 全局变量用于跟踪搜索结果
+LAST_SEARCH_PROVIDER = None
+LAST_SEARCH_COUNT = 0
+
+
+def web_search(query: str, num_results: int | None = None) -> list:
+    """统一网络搜索入口：SerpAPI / Bing / Google CSE / DuckDuckGo。
+
+    优先级：
+    - provider=serpapi 且配置密钥 -> SerpAPI
+    - provider=bing 且配置密钥 -> Bing
+    - provider=google_cse 且配置密钥 -> Google CSE
+    - provider=duckduckgo -> DuckDuckGo
+    - provider=auto -> 依次尝试 SerpAPI -> Bing -> Google CSE -> DuckDuckGo
+    """
+    global LAST_SEARCH_PROVIDER, LAST_SEARCH_COUNT
+
+    provider = (SEARCH_PROVIDER or "auto").lower()
+
+    if provider == "serpapi":
+        if check_serpapi_key():
+            results = _serpapi_search(query, num_results)
+            LAST_SEARCH_PROVIDER = "serpapi"
+            LAST_SEARCH_COUNT = len(results)
+            logging.info(f"WebSearch 使用 provider=serpapi，query='{query}'，返回 {LAST_SEARCH_COUNT} 条结果。")
+            return results
+        else:
+            LAST_SEARCH_COUNT = 0
+            return []
+
+    if provider == "bing":
+        if check_bing_key():
+            results = _bing_search(query, num_results)
+            LAST_SEARCH_PROVIDER = "bing"
+            LAST_SEARCH_COUNT = len(results)
+            logging.info(f"WebSearch 使用 provider=bing，query='{query}'，返回 {LAST_SEARCH_COUNT} 条结果。")
+            return results
+        else:
+            LAST_SEARCH_COUNT = 0
+            return []
+
+    if provider == "google_cse":
+        if check_google_cse():
+            results = _google_cse_search(query, num_results)
+            LAST_SEARCH_PROVIDER = "google_cse"
+            LAST_SEARCH_COUNT = len(results)
+            logging.info(f"WebSearch 使用 provider=google_cse，query='{query}'，返回 {LAST_SEARCH_COUNT} 条结果。")
+            return results
+        else:
+            LAST_SEARCH_COUNT = 0
+            return []
+
+    if provider == "duckduckgo":
+        results = _ddg_search(query, num_results)
+        LAST_SEARCH_PROVIDER = "duckduckgo"
+        LAST_SEARCH_COUNT = len(results)
+        logging.info(f"WebSearch 使用 provider=duckduckgo，query='{query}'，返回 {LAST_SEARCH_COUNT} 条结果。")
+        return results
+
+    # auto 模式回退链
+    if check_serpapi_key():
+        results = _serpapi_search(query, num_results)
+        LAST_SEARCH_PROVIDER = "serpapi"
+        LAST_SEARCH_COUNT = len(results)
+        logging.info(f"WebSearch 使用 provider=serpapi，query='{query}'，返回 {LAST_SEARCH_COUNT} 条结果。")
+        return results
+
+    if check_bing_key():
+        results = _bing_search(query, num_results)
+        LAST_SEARCH_PROVIDER = "bing"
+        LAST_SEARCH_COUNT = len(results)
+        logging.info(f"WebSearch 使用 provider=bing，query='{query}'，返回 {LAST_SEARCH_COUNT} 条结果。")
+        return results
+
+    if check_google_cse():
+        results = _google_cse_search(query, num_results)
+        LAST_SEARCH_PROVIDER = "google_cse"
+        LAST_SEARCH_COUNT = len(results)
+        logging.info(f"WebSearch 使用 provider=google_cse，query='{query}'，返回 {LAST_SEARCH_COUNT} 条结果。")
+        return results
+
+    results = _ddg_search(query, num_results)
+    LAST_SEARCH_PROVIDER = "duckduckgo"
+    LAST_SEARCH_COUNT = len(results)
+    logging.info(f"WebSearch 使用 provider=duckduckgo，query='{query}'，返回 {LAST_SEARCH_COUNT} 条结果。")
+    return results
+
+
+# 兼容旧接口：保留 serpapi_search 名称，但内部转发到 web_search
+def serpapi_search(query: str, num_results: int | None = None) -> list:
+    return web_search(query, num_results)

--- a/logic.py
+++ b/logic.py
@@ -13,7 +13,8 @@ from core.reranker import rerank_documents
 from core.llm_interface import call_ollama_api_stream, call_siliconflow_api, call_siliconflow_api_stream, generate_query_variations
 from core.web_search import serpapi_search
 import core.reranker as reranker  # 导入模块以访问get_cross_encoder
-
+# 新增：导入最近一次网络搜索提供方与结果数（用于调试展示）
+from core.web_search import get_last_search_provider, get_last_search_count
 # 新增：导入 DeepSeek 与 阿里云 API
 from core.llm_interface import (
     call_deepseek_api_stream, call_deepseek_api,
@@ -328,9 +329,22 @@ def recursive_retrieval(initial_query, enable_web_search, model_choice):
         if enable_web_search:
             try:
                 web_results = serpapi_search(query)
-                for res in web_results:
+                for idx, res in enumerate(web_results):
                     # 将网络结果也视为一种上下文
                     text = f"标题：{res.get('title', '')}\n摘要：{res.get('snippet', '')}"
+                # 将网络搜索结果也纳入上下文预算（低优先级地追加）
+                if web_texts:
+                    web_pack = [
+                        (f"web_{j}", {"content": t, "metadata": {"source": "web_search"}})
+                        for j, t in enumerate(web_texts)
+                    ]
+                    _fit_into_budget(
+                        reranked_results=web_pack,
+                        all_contexts=all_contexts,
+                        all_doc_ids=all_doc_ids,
+                        all_metadata=all_metadata,
+                        query=query
+                    )
                     web_texts.append(text)
                     # 为了简单起见，我们不将网络结果加入向量库，只作为当轮的临时上下文
             except Exception as e:
@@ -366,6 +380,13 @@ def answer_question_stream(question, enable_web_search, model_choice, allow_supp
     # 1. 递归检索获取上下文
     yield "🔍 正在搜索相关文档...", "检索中"
     contexts, doc_ids, metadatas = recursive_retrieval(question, enable_web_search, model_choice)
+
+    # 新增：在UI与日志中输出最近一次网络搜索提供方与结果数
+    if enable_web_search:
+        provider = get_last_search_provider() or "none"
+        count = get_last_search_count() or 0
+        logging.info(f"调试：最近一次网络搜索提供方={provider}，结果数={count}")
+        yield f"🧪 调试：网络搜索提供方：{provider}（{count} 条）", "检索中"
 
     # 2. 构建Prompt
     yield "📝 正在构建提示词...", "准备中"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ pydantic==2.11.5
 # 工具依赖
 numpy>=1.26.1
 rank-bm25>=0.2.2
+# 新增：DuckDuckGo 免费搜索
+duckduckgo-search>=6.2.11


### PR DESCRIPTION
本次拉取请求引入了多提供商网络搜索支持，使系统能够在SerpAPI、Bing、谷歌自定义搜索（CSE）和DuckDuckGo之间选择进行网络搜索。它还添加了这些提供商的配置选项，并公开了关于上次搜索提供商和结果数量的调试信息。主要变更分组如下。

### 网络搜索提供商扩展

* 重构了`core/web_search.py`，以支持在SerpAPI、Bing、谷歌CSE和DuckDuckGo之间动态选择，包括强大的 fallback 逻辑和统一的结果格式化。现在的主要入口点是`web_search`，根据配置选择提供商。[[1]](diffhunk://#diff-41962ea891b78959f758ea36b694b0351575c0f117b9314a60587650b472be23L2-L22) [[2]](diffhunk://#diff-41962ea891b78959f758ea36b694b0351575c0f117b9314a60587650b472be23L32-R301)
* 添加了Bing和谷歌CSE的解析和API集成逻辑，包括API密钥和端点的配置。[[1]](diffhunk://#diff-41962ea891b78959f758ea36b694b0351575c0f117b9314a60587650b472be23L2-L22) [[2]](diffhunk://#diff-41962ea891b78959f758ea36b694b0351575c0f117b9314a60587650b472be23L32-R301)

### 配置与设置

* 更新了`config.py`和`config_models.yaml`，添加了新的配置选项：`SEARCH_PROVIDER`、`SEARCH_OVERALL_TIMEOUT`、Bing和谷歌CSE的API密钥和端点，以及网络搜索的提供商选择。[[1]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482R50-R53) [[2]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482R73-R81) [[3]](diffhunk://#diff-9bc9e808c5056c2112ae4248840b66f102b8324eff718662af1c5c0f662c69eeR37-R48)
* 在`app.py`中添加了日志初始化，以确保网络搜索调试输出的可见性。

### 调试和用户界面反馈

* 在`core/web_search.py`中公开了检索上次使用的搜索提供商和结果数量的函数，并在`logic.py`中导入这些函数以供用户界面使用。
* 更新了`logic.py`，在问答过程中向用户记录和显示上次搜索的提供商和结果数量，有助于调试和提高透明度。

### 上下文集成

* 修改了`logic.py`中的上下文打包逻辑，将网络搜索结果纳入检索预算，使其可用于下游处理。

---

这些变更共同实现了具有多提供商的灵活、可配置且透明的网络搜索集成，提高了可靠性和用户反馈。